### PR TITLE
Lower VS Code engine requirement to 1.104.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/JunAkerBuilds/CodeBeats.git"
   },
   "engines": {
-    "vscode": "^1.106.0"
+    "vscode": "^1.104.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
Updated the 'engines.vscode' field in package.json to require a minimum VS Code version of 1.104.0 instead of 1.106.0, allowing compatibility with older VS Code versions.